### PR TITLE
findDomNodeが非推奨になっているので使わないようにする

### DIFF
--- a/packages/core/src/components/Modal/index.tsx
+++ b/packages/core/src/components/Modal/index.tsx
@@ -1,4 +1,4 @@
-import React, { HTMLAttributes } from 'react';
+import React, { useRef, HTMLAttributes } from 'react';
 import styled from 'styled-components';
 import { Transition } from 'react-transition-group';
 import useScrollFix from '../../hooks/useScrollFix';
@@ -87,12 +87,14 @@ export default function Modal({
   className, closeOnOverlay, closeOnEsc,
   ...rest
 }: Props) {
+  const ref = useRef<HTMLDivElement | null>(null);
   useScrollFix(show);
   return (
     <Portal>
       <Transition
         in={show}
         timeout={timeout!}
+        nodeRef={ref}
         unmountOnExit
         mountOnEnter
       >
@@ -100,6 +102,7 @@ export default function Modal({
           <Wrapper
             role="dialog"
             className={className}
+            ref={ref}
           >
             <Shadow onClick={closeOnOverlay ? closeModal : undefined} data-testid="vs-modal-overlay" />
             <AnimatedBox className={state} color={color} borderless {...rest} role="document">


### PR DESCRIPTION
## 対応背景
Reactのstrictモードで開発をしていて、Modalを開くと以下のようなエラーメッセージが出てくる。
```
Warning: findDOMNode is deprecated in StrictMode. findDOMNode was passed an instance of Transition which is inside StrictMode. Instead, add a ref directly to the element you want to reference. Learn more about using refs safely here
```

react-transition-groupで内部的にfindDomNodeが使われているようで、それで