### PR TITLE
Popoverの親にclickイベントが付いていたら、一緒にトリガーされる

### DIFF
--- a/packages/core/src/components/Popover/index.tsx
+++ b/packages/core/src/components/Popover/index.tsx
@@ -48,6 +48,10 @@ export interface PopoverRef {
   close: () => void;
 }
 
+function stopPropagation(e?: React.MouseEvent<HTMLButtonElement | HTMLDivElement>) {
+  e?.stopPropagation();
+}
+
 const Popover = forwardRef(({
   position, label, children, color = 'background',
   onOpen, onClose, disabled, className = '',
@@ -67,13 +71,15 @@ const Popover = forwardRef(({
     },
   );
 
-  const handleFocus = () => {
+  const handleFocus = (e?: React.MouseEvent<HTMLButtonElement>) => {
+    stopPropagation(e);
     setOpen(true);
     requestAnimationFrame(openPopper);
     if (onOpen) onOpen();
   };
 
-  const handleBlur = () => {
+  const handleBlur = (e?: React.MouseEvent<HTMLButtonElement | HTMLDivElement>) => {
+    stopPropagation(e);
     closePopper();
     setOpen(false);
     if (onClose) onClose();
@@ -107,6 +113,7 @@ const Popover = forwardRef(({
             className={className}
             ref={popover}
             color={color}
+            onClick={stopPropagation}
             {...rest}
           >
             {children}

--- a/packages/core/src/components/Popover/index.tsx
+++ b/packages/core/src/components/Popover/index.tsx
@@ -49,7 +49,8 @@ export interface PopoverRef {
 }
 
 function stopPropagation(e?: React.MouseEvent<HTMLButtonElement | HTMLDivElement>) {
-  e?.stopPropagation();
+  if (!e) return;
+  e.stopPropagation();
 }
 
 const Popover = forwardRef(({

--- a/packages/core/src/components/Popover/popover.story.tsx
+++ b/packages/core/src/components/Popover/popover.story.tsx
@@ -66,6 +66,22 @@ storiesOf('components|Popover', module)
         </Popover>
       </>
     );
+  })
+  .add('clickable parent', () => {
+    const [clicked, setClicked] = useState(false);
+    return (
+      <>
+        <button onClick={() => setClicked(!clicked)}>
+          <span>parent button contents</span><br />
+          <Popover
+            label={<button>click me</button>}
+          >
+            <p>hello world</p>
+          </Popover>
+        </button>
+        {clicked ? <div>oh no! you parent click event triggerd!</div> : null}
+      </>
+    );
   });
 
 function Test() {

--- a/packages/core/src/components/Popover/popover.story.tsx
+++ b/packages/core/src/components/Popover/popover.story.tsx
@@ -79,7 +79,7 @@ storiesOf('components|Popover', module)
             <p>hello world</p>
           </Popover>
         </button>
-        {clicked ? <div>oh no! you parent click event triggerd!</div> : null}
+        {clicked ? <div>oh no! your parent click event is triggered!</div> : null}
       </>
     );
   });


### PR DESCRIPTION
Popoverの親にclick eventリスナーが登録されている場合、
Popoverのclick eventが継承され、一緒にトリガーされてしまう。

対象としては
- Popoverのlabelのelement
- Popoverのportalされた中身