### PR TITLE
モーダルコンポーネントにTransitionのonExited発火時に実行されるcallbackを渡せるようにする

### DIFF
--- a/packages/core/src/components/Modal/index.tsx
+++ b/packages/core/src/components/Modal/index.tsx
@@ -80,13 +80,13 @@ interface Props extends HTMLAttributes<HTMLDivElement> {
   /** モーダル外に表示するElements */
   external?: React.ReactNode;
   /** モーダルのtransition exitが完了した時に発火されるcallback */
-  onTransitionExited?: () => void;
+  onExited?: () => void;
 }
 
 export default function Modal({
   show, children, timeout = 200,
   color = 'background', closeModal, external,
-  className, closeOnOverlay, closeOnEsc, onTransitionExited,
+  className, closeOnOverlay, closeOnEsc, onExited,
   ...rest
 }: Props) {
   useScrollFix(show);
@@ -95,7 +95,7 @@ export default function Modal({
       <Transition
         in={show}
         timeout={timeout!}
-        onExited={onTransitionExited}
+        onExited={onExited}
         unmountOnExit
         mountOnEnter
       >

--- a/packages/core/src/components/Modal/index.tsx
+++ b/packages/core/src/components/Modal/index.tsx
@@ -79,12 +79,14 @@ interface Props extends HTMLAttributes<HTMLDivElement> {
   timeout?: number;
   /** モーダル外に表示するElements */
   external?: React.ReactNode;
+  /** モーダルのtransition exitが完了した時に発火されるcallback */
+  onTransitionExited?: () => void;
 }
 
 export default function Modal({
   show, children, timeout = 200,
   color = 'background', closeModal, external,
-  className, closeOnOverlay, closeOnEsc,
+  className, closeOnOverlay, closeOnEsc, onTransitionExited,
   ...rest
 }: Props) {
   useScrollFix(show);
@@ -93,6 +95,7 @@ export default function Modal({
       <Transition
         in={show}
         timeout={timeout!}
+        onExited={onTransitionExited}
         unmountOnExit
         mountOnEnter
       >


### PR DESCRIPTION
モーダルコンポーネントにTransitionのonExited発火時に実行するcallbackを渡せるようにしました。

[背景]
モーダルでの削除実行時など(モーダルを含む)要素が消えてしまう操作をする時、トランジションの終了を待ってから実行したいため。
トランジションの終了を待たずに実行してしまうと、モーダルが閉じ切る前に要素がなくなり不自然になってしまう。